### PR TITLE
fix checkSetQueryString (argument passing)

### DIFF
--- a/helper.pl
+++ b/helper.pl
@@ -38,7 +38,7 @@ sub processGet {
 }
 
 sub checkSetQueryString {
-  my $uri = $_;
+  my $uri = $_[0];
   
   if($uri =~ /\?/) { # has params
     my $params;


### PR DESCRIPTION
fixing checkSetQueryString (problem passing argument)